### PR TITLE
Fix issue with implicit float truncation due to long type being used.

### DIFF
--- a/android/src/main/java/us/mediagrid/capacitorjs/plugins/nativeaudio/AudioSource.java
+++ b/android/src/main/java/us/mediagrid/capacitorjs/plugins/nativeaudio/AudioSource.java
@@ -113,11 +113,11 @@ public class AudioSource extends Binder {
             return -1;
         }
 
-        return duration / 1000;
+        return duration / 1000.0f;
     }
 
     public float getCurrentTime() {
-        return getPlayer().getCurrentPosition() / 1000;
+        return getPlayer().getCurrentPosition() / 1000.0f;
     }
 
     public void play() {


### PR DESCRIPTION
Thanks for making this project available! I ran into this little bug on Android when needing millisecond accurate timings. Hope this helps!